### PR TITLE
Fix print code

### DIFF
--- a/src/print_code.jl
+++ b/src/print_code.jl
@@ -1,9 +1,5 @@
-export print_code
+export print_code, print_eT_code
 using Printf
-
-""" Print term to numpy's einsum routine
-"""
-print_code(t::Term, translation) = print_code(t, "X", translation)
 
 """ Print term to numpy's einsum routine
 """
@@ -45,7 +41,7 @@ function print_code(t::Term, symbol::String, translation)
         end
     end
 
-    println("$(symbol)_$(external) += $scalar_str * np.einsum($einsum_str$tensor_str, optimize=\"optimal\");")
+    "$(symbol)_$(external) += $scalar_str * np.einsum($einsum_str$tensor_str, optimize=\"optimal\");"
 end
 
 """ Used with https://github.com/alexancp/einsumpath-to-eT to generate Fortran subroutines for eT.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -475,3 +475,17 @@ end
     eq2 = permute_tensor(1, 2, 3, 4) * real_tensor("h", 1, 2)
     @test simplify_heavy(eq1) == eq2
 end
+
+@testset "print code" begin
+    using Printf
+    equation = summation(real_tensor("h", 1, 2) * real_tensor("g", 2, 1, 3) * occupied(1) * virtual(2,3), 1:2)
+    trans = translate(VirtualOrbital => [3])
+
+    code = print_code(equation.terms[1], "omega", trans)
+    expected_code = """omega_a +=  +1.00000000 * np.einsum("bia,ib->a", g_vov, h_ov, optimize="optimal");"""
+    @test code == expected_code
+
+    code_eT = print_eT_code(equation.terms[1], "omega", trans, "test")
+    expected_code_eT = """print(generate_eT_code_from_einsum(\n    routine_name=\"test\",\n    prefactor= +1.00000000,\n    contraction_string=\"bia,ib->a\",\n    arrays=[g_vov, h_ov, omega],\n    symbols=[\"g_vov\", \"h_ov\", \"omega\"],\n), end='!\\n!\\n')"""
+    @test code_eT == expected_code_eT
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -477,7 +477,6 @@ end
 end
 
 @testset "print code" begin
-    using Printf
     equation = summation(real_tensor("h", 1, 2) * real_tensor("g", 2, 1, 3) * occupied(1) * virtual(2,3), 1:2)
     trans = translate(VirtualOrbital => [3])
 


### PR DESCRIPTION
Fix `print_code` and export `print_eT_code`. Note that `print_code` now returns a string instead of using println on the string.